### PR TITLE
Update 20533C_LAB_03.md

### DIFF
--- a/Instructions/20533C_LAB_03.md
+++ b/Instructions/20533C_LAB_03.md
@@ -53,7 +53,7 @@ The main tasks for this exercise are as follows:
 
   -  **User name:** Student
 
-  -  **Password:** Pa$$w0rd
+  -  **Password:** Pa$$w0rd1234
 
   -  **Subscription:**_Your subscription_
 


### PR DESCRIPTION
The default password isn't long enough. The password value must be between 12 and 123 characters long. It should be modified in all labs and lab answer keys.

Marcel