### PR TITLE
One Resource Group Rename was omitted

### DIFF
--- a/Instructions/20533C_LAB_AK_04.md
+++ b/Instructions/20533C_LAB_AK_04.md
@@ -52,7 +52,7 @@
 
   - Subscription:  **_Your Azure subscription you intend to use for this demo_**_._
 
-  - Resource group:  **ResDevWebAS**
+  - Resource group:  **ResDevWebRG**
 
   - Location:  **_The same location you chose for the availability set_**_._
 


### PR DESCRIPTION
Previous update omitted renaming the Resource Group to ResDevWebRG in one spot.