### PR TITLE
Update 20533C_LAB_AK_03.md

### DIFF
--- a/Instructions/20533C_LAB_AK_03.md
+++ b/Instructions/20533C_LAB_AK_03.md
@@ -145,7 +145,7 @@
 
   -  **subnetName:** App
 
-  -  **vmSize:** Standard_D1
+  -  **vmSize:** Standard_D1_V2
 
   -  **ubuntuOSVersion:** 14.04.2-LTS
 


### PR DESCRIPTION
vmSize "Standard_D1" is no longer available.  Standard_D1_V2 is a valid input