### PR TITLE
Create placeholderfile.txt

### DIFF
--- a/Allfiles/Labfiles/Lab11/Starter/placeholderfile.txt
+++ b/Allfiles/Labfiles/Lab11/Starter/placeholderfile.txt
@@ -1,0 +1,3 @@
+This file exists only to create the Starter directory.
+
+When running the Setup-Azure command for Lab-11, it puts a .RDP file in the Starter Directory.  Unless that folder exists, one of the commands in the setup will fail.


### PR DESCRIPTION
When running the Setup-Azure command for Lab-11, it puts a .RDP file in the LabFiles\Lab11\Starter Directory.  

Unless that folder exists, one of the commands in the setup-azure will fail.  This file exists to create that directory so the .RDP file is placed correctly.