### PR TITLE
Change address space to avoid overlap

### DIFF
--- a/Instructions/20533C_LAB_02.md
+++ b/Instructions/20533C_LAB_02.md
@@ -125,9 +125,9 @@ The main tasks for this exercise are as follows:
 
 2. Select your subscription by using the  **Set-AzureRMContext** command, and then use **New-AzureRMResourceGroup** command to create a new resource group named **AdatumTestRG** in the primary Azure region provided by the instructor.
 
-3. By using the  **New-AzureRMVirtualNetwork** command, create a new virtual network named **AdatumTestVnet** with the address space **10.0.0.0/16** in the same region as the resource group.
+3. By using the  **New-AzureRMVirtualNetwork** command, create a new virtual network named **AdatumTestVnet** with the address space **10.1.0.0/16** in the same region as the resource group.
 
-4. Add a subnet named  **FrontEnd** with the IP range of 10.0.0.0/24 to the virtual network **AdatumTestVNet**.
+4. Add a subnet named  **FrontEnd** with the IP range of 10.1.0.0/24 to the virtual network **AdatumTestVNet**.
 
 
 >  **Result**: After completing this exercise, you should have created a test virtual networks for A. Datum by using Azure PowerShell. 


### PR DESCRIPTION
Exercise 2 is just to show how to create a test vnet. This VNet is not used any more. However it causes an overlap with exercise 3.
So better to change the address space of this test VNet to 10.1.0.0.