### PR TITLE
New updates in the new portal

### DIFF
--- a/Instructions/20533C_LAB_AK_03.md
+++ b/Instructions/20533C_LAB_AK_03.md
@@ -9,40 +9,58 @@
 
 2. Sign in using the Microsoft account that is either the Service Administrator or Co-administrator of your subscription.
 
-3. On the Hub menu, click  **Virtual machines**, and then, on the Virtual machines blade, click  **Add**.
+3. In the navigation pane on the left side of the Azure Portal, scroll down, and click **More Services**
 
-4. On the Virtual Machines blade, click  **Windows Server**.
+4. In the **Browse** blade that displays, view your list of Virtual Machine instances.
 
-5. On the Windows Server blade, click  **Windows Server 2012 R2 Datacenter,** and then on the Windows Server 2012 R2 Datacenter blade, ensure that **Resource Manager** appears in the **Select a deployment model** list box, and then click **Create**. 
+5. At the top of the **Virtual machines** blade that displays, click the *Add** button.
 
-6. On the Basics blade, specify the following:
+6. On the Virtual Machines blade, click  **Windows Server**.
+
+7. On the Windows Server blade, click  **Windows Server 2012 R2 Datacenter,** and then on the Windows Server 2012 R2 Datacenter blade, ensure that **Resource Manager** appears in the **Select a deployment model** list box, and then click **Create**. 
+
+8. On the Basics blade, specify the following:
 
 
   -  **Name:** ResDevDB1
+  
+  -  **VM disk type:** HDD
 
   -  **User name:** Student
 
-  -  **Password:** Pa$$w0rd
+  -  **Password:** Pa$$w0rd1234
 
   -  **Subscription:**_Your subscription_
 
 
-1.  **In the** **Resource group** **section, click the drop-down list and clickResDevRG**. 
+9.  **In the** **Resource group** **section, click the drop-down list and select **ResDevRG**. 
 
-2. Accept the default Location value and click  **OK**.
+10. Accept the default Location value and click  **OK**.
 
-3. On the Choose a size blade, click  **A1**
+11. On the Choose a size blade, click  **A1**
  **Standard**, and then click  **Select**.
+ 
+12. On the Settings blade, ensure that  **HQ-VNET** is selected as the **Virtual network**.
 
-4. On the Settings blade, ensure that  **HQ-VNET** is selected as the **Virtual network**.
+13. Click  **Subnet**.
 
-5. Click  **Subnet**.
+14. On the Choose subnet blade, click  **Database**.
 
-6. On the Choose subnet blade, click  **Database**.
+15. Click on the Storage Account and click **Create new**.
 
-7. On the Settings blade, click  **OK**
+16. On the **Create storage account**, specify the following:
 
-8. On the Summary blade, click  **OK**.
+  -  **Name:** 20533lab03store[unique number]
+  
+  -  **Performance:** Standard
+
+  -  **Replication:** Locally-redundant storage (LRS)
+
+17. On the Create storage account blade, click **OK**.  
+
+18. On the Settings blade, click  **OK**.
+
+19. On the Summary blade, click  **OK**.
 
 >  **Note:** You can monitor the virtual machine's deployment progress on the Dashboard page.
 
@@ -98,6 +116,7 @@
 
   -  **Virtual network/subnet: HQ-VNET/Database**
 
+  -  **Storage account:** make sure the storage account created in this lab is selected
 
 1. Repeat steps 4 and 5 for the  **ResDevDB2** virtual machine.
 


### PR DESCRIPTION
New updates in the new portal: 
-vm disk type, 
-new description to select More Services, 
-added the creation of a storage account for this lab (when student don't reset the labs, it chooses the storage account from lab 2). If not, the journey selects a previous created account from another Resource Group and the CreateRmVM.ps1 script will fail. The DSC will also fail.

To make it more solid, you must be sure that your Resource Group has a Storage Account. After Reset Azure there is no storage account, However student continue without an Azure Reset because it takes a very long time.