### PR TITLE
Get specific access key changed

### DIFF
--- a/Allfiles/Labfiles/Lab04/Starter/DeployAzureDSC.ps1
+++ b/Allfiles/Labfiles/Lab04/Starter/DeployAzureDSC.ps1
@@ -5,7 +5,7 @@ Show-SubscriptionARM
 $resourceGroupName = 'ResDevWebRG'
 
 $storageAccount = Get-AzureRmStorageAccount -ResourceGroupName $resourceGroupName
-$storageAccountKey = (Get-AzureRmStorageAccountKey -ResourceGroupName $resourceGroupName -Name $storageAccount.StorageAccountName).Key1
+$storageAccountKey = (Get-AzureRmStorageAccountKey -ResourceGroupName $resourceGroupName -Name $storageAccount.StorageAccountName).Value[0]
 
 # we are using default container 
 $containerName = 'windows-powershell-dsc'


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/mt607145.aspx

Example 2: Get a specific access key for a Storage account
 
This command gets a specific key for a Storage account. This command works for Azure PowerShell version 1.4, and later versions.

Windows PowerShell
PS C:\> (Get-AzureRmStorageAccountKey -ResourceGroupName "RG01" -AccountName "MyStorageAccount").Value[0]
 
This command gets a specific key for a Storage account. This command works for Azure PowerShell version 1.3.2, and previous versions.

Windows PowerShell
PS C:\> (Get-AzureRmStorageAccountKey -ResourceGroupName "RG01" -AccountName "MyStorageAccount").Key1