### PR TITLE
Lowercase characters for an storage account name

### DIFF
--- a/Allfiles/Labfiles/Lab01/Starter/Lab01Starter.ps1
+++ b/Allfiles/Labfiles/Lab01/Starter/Lab01Starter.ps1
@@ -4,7 +4,7 @@
 $locName = "East US" #Azure datacenter location
 $rgName = "TestRG1" # test resource group created in Exercise 2
 $newrgName ="TestWebRG" # resource group name to which the storage account will re-assigned
-$webappName = "TestWebAppMMDDYYAB" #storage account name. This must be all lower case, and a name that is unique across Azure
+$webappName = "testwebappMMDDYYab" #storage account name. This must be all lower case, and a name that is unique across Azure
 
 #Create a new Web app in the TestRG1 resource group, using the variables above
 


### PR DESCRIPTION
Use lowercase characters for an storage account name, so also in the example .