### PR TITLE
Fixed syntax error

### DIFF
--- a/Allfiles/Labfiles/Lab10/Starter/Setup-20533C10Lab.ps1
+++ b/Allfiles/Labfiles/Lab10/Starter/Setup-20533C10Lab.ps1
@@ -48,7 +48,7 @@ if ($uploadArtifacts) {
 
     # Create a storage account name if none was provided
     if ($StorageAccountName -eq $null) {
-        $StorageAccountName = 'stage' + ((Get-AzureRmContext).Subscription.SubscriptionId).Replace('-', '').substring(0, 19)
+        $StorageAccountName = 'stage' + ((Get-AzureRmContext).Subscription.Id).Replace('-', '').substring(0, 19)
     }
 
     $StorageAccount = (Get-AzureRmStorageAccount | Where-Object{$_.StorageAccountName -eq $StorageAccountName})


### PR DESCRIPTION
(Get-AzureRmContext).Subscription.SubscriptionId are in current Powershell Module not a valid command. The parameter SubscriptionId are not part of (Get-AzureRmContext).Subscription.