### PR TITLE
escape a backslash

### DIFF
--- a/Instructions/20533C_LAB_10.md
+++ b/Instructions/20533C_LAB_10.md
@@ -53,7 +53,7 @@ The main tasks for this exercise are as follows:
 
 4. If necessary, in the Azure portal, switch to the Default Directory.
 
-5. Initiate a Remote Desktop Protocol (RDP) session to **adVM**, and then sign in as **ADATUM\Student** with the password **Pa55w.rd1234**.
+5. Initiate a Remote Desktop Protocol (RDP) session to **adVM**, and then sign in as **ADATUM\\Student** with the password **Pa55w.rd1234**.
 
 6. In the Remote Desktop session, start Windows PowerShell ISE as administrator, paste the content of Clipboard into the script pane and run the pasted commands.
 


### PR DESCRIPTION
replaced the logon name "ADATUM\Student" by "ADATUM\\Student" for doc export format.