### PR TITLE
Minor typo

### DIFF
--- a/Instructions/20533D_LAB_AK_05.md
+++ b/Instructions/20533D_LAB_AK_05.md
@@ -367,7 +367,7 @@
 
 #### Task 4: Test Traffic Manager
   
-1. In Microsoft Edge, in the Azure portal, on the traffic Manager profile blade, click **Overview**, wait until the ONLINE column displays the **Online** status for both web apps, and then, click the link under the **DNS name** section.
+1. In Microsoft Edge, in the Azure portal, on the traffic Manager profile blade, click **Overview**, wait until the MONITOR STATUS column displays the **Online** status for both web apps, and then, click the link under the **DNS name** section.
 
 2. Microsoft Edge displays the Adatum web app. 
 


### PR DESCRIPTION
replaced the "ONLINE" column with the "MONITOR STATUS" in column name of the traffic manager profile overview.