### PR TITLE
Remove unnecessary test in Deploy-20533E0401DSC.ps1

### DIFF
--- a/Allfiles/Labfiles/Lab04/Starter/Deploy-20533E0401DSC.ps1
+++ b/Allfiles/Labfiles/Lab04/Starter/Deploy-20533E0401DSC.ps1
@@ -10,14 +10,10 @@ $resourceGroup = Get-AzureRmResourceGroup -Name $resourceGroupName
 
 $storageAccount = Get-AzureRmStorageAccount -ResourceGroupName $resourceGroupName
 If (!($storageAccount)) {
-    $uniqueNumber = Get-Random
-    $saName = $saPrefix + $uniqueNumber 
-    If ((Get-AzureRmStorageAccountNameAvailability -Name $saName).NameAvailable -ne $True) { 
-        Do { 
-            $uniqueNumber = Get-Random
-            $saName = $saPrefix + $uniqueNumber
-        } Until ((Get-AzureRmStorageAccountNameAvailability -Name $saName).NameAvailable -eq $True)
-    } 
+    Do { 
+        $uniqueNumber = Get-Random
+        $saName = $saPrefix + $uniqueNumber
+    } Until ((Get-AzureRmStorageAccountNameAvailability -Name $saName).NameAvailable -eq $True)
     $storageAccount = New-AzureRmStorageAccount -ResourceGroupName $resourceGroupname -Name $saName -Type $saType -Location $resourceGroup.Location
 }
 


### PR DESCRIPTION
In Deploy-20533E0401DSC.ps1, the scripts generates a name for the storageAccount ($saName) then checks for its availability. If it's not available, it starts looping until it finds an available name.
It is unnecessary to do the first If, as the loop is a Do...Until construction and will always be executed once.