### PR TITLE
formatting of "replace with" items

### DIFF
--- a/Instructions/20533E_LAB_AK_01.md
+++ b/Instructions/20533E_LAB_AK_01.md
@@ -269,7 +269,7 @@ az resource list --resource-group 20533E0102-LabRG
 
 3. In the output of the previous command, at **Administrator: Command Prompt**, note the value of the **id** property of the **20533E0101-rt**. You will use this value in the next command.
 
-4. From **Administrator: Command Prompt**, type the following command (replace **`guid`** with ID of your Azure subscrption) and then press Enter:
+4. From **Administrator: Command Prompt**, type the following command (replace ***guid*** with **ID** of your Azure subscrption) and then press Enter:
 
 ```
 az resource move --ids "/subscriptions/{guid}/resourceGroups/20533E0102-LabRG/providers/Microsoft.Network/routeTables/20533E0101-rt" --destination-group "20533E0101-LabRG"

--- a/Instructions/20533E_LAB_AK_02.md
+++ b/Instructions/20533E_LAB_AK_02.md
@@ -76,19 +76,19 @@ Add-AzureRmAccount
 Get-AzureRmSubscription
 ```
 
-5. Note the value of the **`Id`** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual SubscriptionId property of that subscription):
+5. Note the value of the ***Id*** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual SubscriptionId property of that subscription):
 
 ```
 Set-AzureRmContext -SubscriptionId 'SubscriptionId'
 ```
 
-6. To create a new resource group, type the following command, and then press Enter (replace **`AzureRegion`** with the name of the same Azure region you chose in the previous exercise):
+6. To create a new resource group, type the following command, and then press Enter (replace ***AzureRegion*** with the name of the same Azure region you chose in the previous exercise):
 
 ```
 $rg = New-AzureRMResourceGroup -Name '20533E0204-LabRG' -Location 'AzureRegion'
 ```
 
-7. To create a new virtual network named **20533E0204-vnet** with the address space **10.11.0.0/16** and store a reference to it in the **`$vnet`** variable, type the following command, and then press Enter:
+7. To create a new virtual network named **20533E0204-vnet** with the address space **10.11.0.0/16** and store a reference to it in the ***$vnet*** variable, type the following command, and then press Enter:
 
 ```
 $vnet = New-AzureRmVirtualNetwork -ResourceGroupName $rg.ResourceGroupName -Name '20533E0204-vnet' -AddressPrefix '10.11.0.0/16' -Location $rg.Location
@@ -135,19 +135,19 @@ az login
 az account show
 ```
 
-8. Note the value of the '***id***' property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual SubscriptionId property of that subscription):
+8. Note the value of the '***id***' property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual SubscriptionId property of that subscription):
 
 ```
 az account set --subscription "SubscriptionId"
 ```
 
-9. To create a new resource group, type the following command, and then press Enter (replace **`AzureRegion`** with the name of the same Azure region you chose in the previous exercise):
+9. To create a new resource group, type the following command, and then press Enter (replace ***AzureRegion*** with the name of the same Azure region you chose in the previous exercise):
 
 ```
 az group create --name 20533E0205-LabRG --location "AzureRegion"
 ```
 
-10. To create a new virtual network named **20533E0205-vnet** with the address space **10.12.0.0/16** and a subnet named Subnet1 with the address prefix of 10.12.0.0/24, type the following command, and then press Enter (replace **`AzureRegion`** with the name of the same Azure region you chose in the previous exercise):
+10. To create a new virtual network named **20533E0205-vnet** with the address space **10.12.0.0/16** and a subnet named Subnet1 with the address prefix of 10.12.0.0/24, type the following command, and then press Enter (replace ***AzureRegion*** with the name of the same Azure region you chose in the previous exercise):
 
 ```
 az network vnet create --name 20533E0205-vnet --resource-group 20533E0205-LabRG --location "AzureRegion" --address-prefix 10.12.0.0/16 --subnet-name Subnet1 --subnet-prefix 10.12.0.0/24

--- a/Instructions/20533E_LAB_AK_03.md
+++ b/Instructions/20533E_LAB_AK_03.md
@@ -210,7 +210,7 @@ Add-AzureRmAccount
 Get-AzureRmSubscription
 ```
 
-5. Note the value of the **`Id`** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual SubscriptionId property of that subscription):
+5. Note the value of the ***Id*** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual SubscriptionId property of that subscription):
 
 ```
 Set-AzureRmContext -SubscriptionId 'SubscriptionId'
@@ -315,7 +315,7 @@ az login
 az account show
 ```
 
-8. Note the value of the **`id`** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual SubscriptionId property of that subscription):
+8. Note the value of the ***Id*** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual SubscriptionId property of that subscription):
 
 ```
 az account set --subscription "SubscriptionId"

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -67,7 +67,7 @@ Add-AzureRmAccount
 Get-AzureRmSubscription
 ```
 
-11. Note the value of the **`Id`** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual **SubscriptionId** property of that subscription):
+11. Note the value of the ***Id*** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual **SubscriptionId** property of that subscription):
 
 ```
 Set-AzureRmContext -SubscriptionId 'SubscriptionId'
@@ -81,7 +81,7 @@ Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
 
 13. Verify that the output references the web app that you created in the previous task.
 
-14. Type the following and then press Enter. Replace **`Name of your web app`** with the name of the web app you chose in the previous task: 
+14. Type the following and then press Enter. Replace ***Name of your web app*** with the name of the web app you chose in the previous task: 
 
 ```
 Get-AzureRMWebAppSlot -ResourceGroupName '20533E0501-LabRG' -Name 'Name of your web app'
@@ -251,13 +251,13 @@ Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
 
 3. Note the name of your original web app and its location.
 
-4. Choose an Azure region that is different from the location of the original web app, preferably on another continent. This will become the **`SecondLocation`**. To identify names of Azure regions, at the Windows PowerShell prompt, type the following command, and then press Enter:
+4. Choose an Azure region that is different from the location of the original web app, preferably on another continent. This will become the ***SecondLocation***. To identify names of Azure regions, at the Windows PowerShell prompt, type the following command, and then press Enter:
 
 ```
 ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).Locations
 ```
 
-5. At the Windows PowerShell prompt, type the following command to create a new resource group, and then press Enter (replace **`SecondLocation`** with the name of the Azure region you chose):
+5. At the Windows PowerShell prompt, type the following command to create a new resource group, and then press Enter (replace ***SecondLocation*** with the name of the Azure region you chose):
 
 ```
 $rg2 = New-AzureRMResourceGroup -Name '20533E0502-LabRG' -Location 'SecondLocation'
@@ -269,7 +269,7 @@ $rg2 = New-AzureRMResourceGroup -Name '20533E0502-LabRG' -Location 'SecondLocati
 $appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard -Name '20533E0502LabPlan' -ResourceGroupName $rg2.ResourceGroupName
 ```
 
-7. At the Windows PowerShell prompt, type the following command (where the **`webappname2`** is a unique name that you will assign to a new web app you will create in the **`SecondLocation`** in the next step), and then press Enter:
+7. At the Windows PowerShell prompt, type the following command (where the ***webappname2*** is a unique name that you will assign to a new web app you will create in the ***SecondLocation*** in the next step), and then press Enter:
 
 ```
 Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
@@ -277,7 +277,7 @@ Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Locati
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 
-9. At the Windows PowerShell prompt, type the following command to create a new web app, and then press Enter (the **`webappname2`** matches the name you identified in the previous step):
+9. At the Windows PowerShell prompt, type the following command to create a new web app, and then press Enter (the ***webappname2*** matches the name you identified in the previous step):
 
 ```
 New-AzureRMWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' -Location $rg2.Location -AppServicePlan $appSvcPlan2.Name
@@ -381,7 +381,7 @@ New-AzureRMWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' 
 
 3. On MIA-CL1, click **Start**, in the Start menu, expand the **Windows System** folder, right-click **Command Prompt**, click **More**, and then click **Run as administrator**. When prompted by User Account Control for confirmation, click **Yes**.
 
-4. At the Command Prompt, type the following command, replacing **`dnsname`** with the fully qualified DNS name of the Traffic Manager profile, and then press Enter:
+4. At the Command Prompt, type the following command, replacing ***dnsname*** with the fully qualified DNS name of the Traffic Manager profile, and then press Enter:
 
 ```
 nslookup dnsname
@@ -397,7 +397,7 @@ nslookup dnsname
 
 9. On the endpoint blade, click **Disabled**, and then click **Save**.
 
-10. Switch to the command prompt, type the following command, replacing **`dnsname`** with the fully qualified DNS name of the Traffic Manager profile, and then press Enter:
+10. Switch to the command prompt, type the following command, replacing ***dnsname*** with the fully qualified DNS name of the Traffic Manager profile, and then press Enter:
 
 ```
 nslookup dnsname

--- a/Instructions/20533E_LAB_AK_06.md
+++ b/Instructions/20533E_LAB_AK_06.md
@@ -85,11 +85,11 @@
 
 3. On the access keys blade, click the **Click to copy** icon next to **Storage account name**. If prompted to allow access to Clipboard, click **Allow access**.
 
-4. Switch to the **Administrator: Windows PowerShell ISE** window and replace the **`<storage-account-name>`** entry with the content of Clipboard.
+4. Switch to the **Administrator: Windows PowerShell ISE** window and replace the ***\<storage-account-name\>*** entry with the content of Clipboard.
 
 5. Switch to the Microsoft Edge window and, on the access keys blade, click the **Click to copy** icon next to **key1**. 
 
-6. Switch to the **Administrator: Windows PowerShell ISE** window and replace the **`<access-key>`** entry with the content of Clipboard.
+6. Switch to the **Administrator: Windows PowerShell ISE** window and replace the ***\<access-key\>*** entry with the content of Clipboard.
 
 7. Press the **F5** key to execute the command in the script pane.
 
@@ -128,7 +128,7 @@ Add-AzureRmAccount
 Get-AzureRmSubscription
 ```
 
-5. Note the value of the **`Id`** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace **`SubscriptionId`** with the actual SubscriptionId property of that subscription):
+5. Note the value of the ***Id*** property for each subscription in the output of the previous command. To specify the subscription in which you are going to create a virtual network, type the following commands, and then press Enter (replace ***SubscriptionId*** with the actual SubscriptionId property of that subscription):
 
 ```
 Set-AzureRmContext -SubscriptionId 'SubscriptionId'
@@ -138,11 +138,11 @@ Set-AzureRmContext -SubscriptionId 'SubscriptionId'
 
 7. In the **Open** dialog box, browse to **F:\\Labfiles\\Lab06\\Starter\\**, click **New-20533E06FileShare.ps1**, and then click **Open**.
 
-8. In the script pane, in the **$storageAccountName** variable declaration at the beginning, replace the **`<storage-account-name>`** value with the name of the Azure storage account that you created in the previous exercise.
+8. In the script pane, in the **\$storageAccountName** variable declaration at the beginning, replace the ***\<storage-account-name\>*** value with the name of the Azure storage account that you created in the previous exercise.
 
 9. Review the script, noting that it:
 
-  - Sets the values of variables named **$shareName** and **$directoryName** for the file share and the directory to create in the Azure Storage account
+  - Sets the values of variables named **\$shareName** and **\$directoryName** for the file share and the directory to create in the Azure Storage account
 	
   - Uses the **Get-AzureRmStorageAccountKey** cmdlet to retrieve the access key for your storage account.
 

--- a/Instructions/20533E_LAB_AK_09.md
+++ b/Instructions/20533E_LAB_AK_09.md
@@ -225,7 +225,7 @@ Connect-MsolService
 New-MsolUser -UserPrincipalName mledford@<#Copy your Azure Directory domain name here#>.onmicrosoft.com -DisplayName 'Mario Ledford' -FirstName 'Mario' -LastName 'Ledford' -Password 'Pa55w.rd' -ForceChangePassword $false -UsageLocation 'US'
 ```
 
-8. Replace **`<#Copy your Azure Directory domain name here#>`** with the unique name you used to specify the DNS domain name of the Adatum Azure AD tenant in the first exercise of this lab.
+8. Replace ***\<#Copy your Azure Directory domain name here#\>*** with the unique name you used to specify the DNS domain name of the Adatum Azure AD tenant in the first exercise of this lab.
 
 9. In the PowerShell ISE window, in the script pane, select the code that you just edited.
 


### PR DESCRIPTION
the tick character inline does not produce the nice effect in the docx that it does in html, replaced it with the standard bold-italics used everwhere else we need to replace something in a command. That required a couple of escape characters to be added.