### PR TITLE
adding missing vmsize param

### DIFF
--- a/Instructions/20533E_LAB_03.md
+++ b/Instructions/20533E_LAB_03.md
@@ -322,7 +322,7 @@ The main tasks for this exercise are as follows:
 
 5. Run the **az group deployment create** command to create a deployment named **WebTierVM2-Deployment** of an Azure VM named **20533E03LabVM6** into the virtual network **20533E0301-LabVNet** and the resource group **20533E0301-LabRG** by using the template **F:\\Labfiles\\Lab03\Starter\\Templates\\azuredeploywebvm.json** 
 
-6. When prompted to provide securestring value for **adminUsername** and **adminPassword**, type **Student** and **Pa55w.rd1234**, respectively.
+6. When prompted to provide securestring value for **adminUsername** , **adminPassword** , **vmSize** , type **Student** , **Pa55w.rd1234**, **Standard_D1_v2** respectively.
 
 
 #### Task 2: Use the Azure portal to monitor deployment

--- a/Instructions/20533E_LAB_03.md
+++ b/Instructions/20533E_LAB_03.md
@@ -269,6 +269,8 @@ The main tasks for this exercise are as follows:
 
   - virtualNetworkName: **20533E0301-LabVNet**
 
+  - vmSize: **Standard_D1_v2**
+
 
 #### Task 2: Use the Azure portal to monitor deployment
   

--- a/Instructions/20533E_LAB_AK_03.md
+++ b/Instructions/20533E_LAB_AK_03.md
@@ -264,6 +264,8 @@ Find-AzureRmResource -ResourceGroupNameContains 20533E0301-LabRG | Format-Table 
 
   - virtualNetworkName: **20533E0301-LabVNet**
 
+  - vmSize: **Standard_D1_v2**
+
 
 #### Task 2: Use the Azure portal to monitor deployment
 

--- a/Instructions/20533E_LAB_AK_03.md
+++ b/Instructions/20533E_LAB_AK_03.md
@@ -333,6 +333,8 @@ az group deployment create --name "WebTierVM2-Deployment" --resource-group "2053
 
 11. When prompted to provide securestring value for **adminPassword**, type **Pa55w.rd1234** and press **Enter**.
 
+12. When prompted to provide value for **vmSize**, type **Standard_D1_v2** and press **Enter**.
+
 
 #### Task 2: Use the Azure portal to monitor deployment
 


### PR DESCRIPTION
 Deploy-AzureResourceGroup.ps1 requires vmSize param but it is not listed in either of the lab files so adding it in.

    "vmSize": {
      "type": "string",
      "metadata": {
        "description": "VM size"
      }
    },

No default value set... hence it is asking for it.

![image](https://user-images.githubusercontent.com/28607803/45300854-5f1dff00-b507-11e8-8bc3-73cc5ab4a393.png)
