### PR TITLE
Add get-azurermlocation option plus note to dns verification

### DIFF
--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -256,7 +256,7 @@ Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
 ```
 ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).Locations
 or
-Get-AzureRmLocation | Select-Object Property Location, DisplayName
+Get-AzureRmLocation | Select-Object -Property Location, DisplayName
 ```
 
 5. At the Windows PowerShell prompt, type the following command to create a new resource group, and then press Enter (replace ***SecondLocation*** with the name of the Azure region you chose):

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -84,7 +84,7 @@ Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
 14. Type the following and then press Enter. Replace ***Name of your web app*** with the name of the web app you chose in the previous task: 
 
 ```
-Get-AzureRMWebAppSlot -ResourceGroupName '20533E0501-LabRG' -Name 'Name of your web app'
+Get-AzureRmWebAppSlot -ResourceGroupName '20533E0501-LabRG' -Name 'Name of your web app'
 ```
 
 15. Verify that the web app staging slot you created in this task is listed in the output
@@ -245,49 +245,50 @@ Get-AzureRMWebAppSlot -ResourceGroupName '20533E0501-LabRG' -Name 'Name of your 
 
 2. At the Windows PowerShell prompt, type the following command, and then press Enter:
 
-```
-Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
-```
+    ```
+    Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
+    ```
 
 3. Note the name of your original web app and its location.
 
 4. Choose an Azure region that is different from the location of the original web app, preferably on another continent. This will become the ***SecondLocation***. To identify names of Azure regions, at the Windows PowerShell prompt, type the following command, and then press Enter:
 
-```
-((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).Locations
-or
-Get-AzureRmLocation | Select-Object -Property Location, DisplayName
-```
+    ```
+    ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).Locations
+    ```
+
+    > **Note:** You can also use
+    >``` Get-AzureRmLocation | Select-Object -Property Location, DisplayName``` or ```(Get-AzureRmLocation).Location```
 
 5. At the Windows PowerShell prompt, type the following command to create a new resource group, and then press Enter (replace ***SecondLocation*** with the name of the Azure region you chose):
 
-```
-$rg2 = New-AzureRMResourceGroup -Name '20533E0502-LabRG' -Location 'SecondLocation'
-```
+    ```
+    $rg2 = New-AzureRmResourceGroup -Name '20533E0502-LabRG' -Location 'SecondLocation'
+    ```
 
 6. At the Windows PowerShell prompt, type the following command to create a new App Service Plan, and then press Enter:
 
-```
-$appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard -Name '20533E0502LabPlan' -ResourceGroupName $rg2.ResourceGroupName
-```
+    ```
+    $appSvcPlan2 = New-AzureRmAppServicePlan -Location $rg2.Location -Tier Standard -Name '20533E0502LabPlan' -ResourceGroupName $rg2.ResourceGroupName
+    ```
 
 7. At the Windows PowerShell prompt, type the following command (where the ***webappname2*** is a unique name that you will assign to a new web app you will create in the ***SecondLocation*** in the next step), and then press Enter:
 
-```
-Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
-```
+    ```
+    Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
+    ```
 
->> **Note:** This command is case sensitive and accepts lower case only but the WebApp name is not; therefore, you can verify whether DNS is taken but then you can still use upper case to create your Web App in step 9.
+    > **Note:** This command is case sensitive and accepts lower case only but the WebApp name is not; therefore, you can verify whether DNS is taken but then you can still use upper case to create your Web App in step 9.
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 
 9. At the Windows PowerShell prompt, type the following command to create a new web app, and then press Enter (the ***webappname2*** matches the name you identified in the previous step):
 
-```
-New-AzureRMWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' -Location $rg2.Location -AppServicePlan $appSvcPlan2.Name
-```
+    ```
+    New-AzureRmWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' -Location $rg2.Location -AppServicePlan $appSvcPlan2.Name
+    ```
 
-> **Note:** If this cmdlet returns an error change the 'webappname2' value.
+    > **Note:** If this cmdlet returns an error change the 'webappname2' value.
 
 10. Switch to the Azure portal in the Microsoft Edge window.
 
@@ -317,13 +318,13 @@ New-AzureRMWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' 
 
 23. Select the **.PublishSettings** file that you downloaded in step 13 of this task, and then click **Open**.
 
-23. This will automatically build and publish the web app from Visual Studio to the Azure Web app you created in this task and open a new tab in the Microsoft Edge window displaying it.
+24. This will automatically build and publish the web app from Visual Studio to the Azure Web app you created in this task and open a new tab in the Microsoft Edge window displaying it.
 
-24. Verify that A. Datum's web app is open in a new Microsoft Edge tab and verify the web app's URL.
+25. Verify that A. Datum's web app is open in a new Microsoft Edge tab and verify the web app's URL.
 
-25. Close the new Microsoft Edge tab.
+26. Close the new Microsoft Edge tab.
 
-26. Close Visual Studio.
+27. Close Visual Studio.
 
 
 #### Task 2: Create a Traffic Manager profile

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -277,7 +277,7 @@ $appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard 
 Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
 ```
 
->> **Note:** This command is case sensitive and accepts lower case only but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Web App in step 9.
+>> **Note:** This command is case sensitive and accepts lower case only but the WebApp name is not; therefore, you can verify whether DNS is taken but then you can still use upper case to create your Web App in step 9.
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -255,6 +255,8 @@ Get-AzureRmWebApp -ResourceGroupName '20533E0501-LabRG'
 
 ```
 ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).Locations
+or
+Get-AzureRmLocation | Select-Object Property Location, DisplayName
 ```
 
 5. At the Windows PowerShell prompt, type the following command to create a new resource group, and then press Enter (replace ***SecondLocation*** with the name of the Azure region you chose):
@@ -274,6 +276,8 @@ $appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard 
 ```
 Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
 ```
+
+>> **Note:** This command is case sensitive but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Webb App in step 9.
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -277,7 +277,7 @@ $appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard 
 Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
 ```
 
->> **Note:** This command is case sensitive but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Webb App in step 9.
+>> **Note:** This command is case sensitive and accepts lower case only but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Webb App in step 9.
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 

--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -277,7 +277,7 @@ $appSvcPlan2 = New-AzureRMAppServicePlan -Location $rg2.Location -Tier Standard 
 Test-AzureRmDnsAvailability -DomainNameLabel 'webappname2' -Location $rg2.Location
 ```
 
->> **Note:** This command is case sensitive and accepts lower case only but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Webb App in step 9.
+>> **Note:** This command is case sensitive and accepts lower case only but the WebPpp name is not; therefore, you can verify whether DNS is taken but then you can still use different case to create your Web App in step 9.
 
 8. Verify that the command returns **True**. If not, keep re-running the same command but with different values of the **DomainNameLabel** parameter.
 


### PR DESCRIPTION
Get-AzureRmLocation is much easier to use to find the location and it is even use in the module itself once:
https://github.com/MicrosoftLearning/20533-ImplementingMicrosoftAzureInfrastructureSolutions/blob/4458d92f687fe633416db9eb1746eed582f70d41/Allfiles/Modules/Select-20533ELocationARM/Select-20533ELocationARM.psm1#L14

Test-AzureRmDnsAvailability 
This command is case sensitive and accepts lower case only but the WebApp name is not; therefore, you can verify whether DNS is taken but then you can still use upper case to create your Web App in step 9.

Example:
![image](https://user-images.githubusercontent.com/28607803/45347098-1ae03c80-b5a3-11e8-8477-4c024c166bf6.png)

Cmdlet would insist that the name is wrong but in reality I could have matched the case from above WebApp.
![image](https://user-images.githubusercontent.com/28607803/45347175-5da21480-b5a3-11e8-8135-c34e0f8b339f.png)


