### PR TITLE
fix dns link that is not a link

### DIFF
--- a/Instructions/20533E_LAB_AK_05.md
+++ b/Instructions/20533E_LAB_AK_05.md
@@ -375,7 +375,7 @@ New-AzureRMWebApp -ResourceGroupName $rg2.ResourceGroupName -Name 'webappname2' 
 
 #### Task 4: Test Traffic Manager
   
-1. In Microsoft Edge, in the Azure portal, on the traffic Manager profile blade, click **Overview**, wait until the **MONITOR STATUS** column displays the **Online** status for both web apps, and then, click the link under the **DNS name** section.
+1. In Microsoft Edge, in the Azure portal, on the traffic Manager profile blade, click **Overview**, wait until the **MONITOR STATUS** column displays the **Online** status for both web apps, and then, copy the URL to Microsoft Edge browser under the **DNS name** section.
 
 2. Microsoft Edge displays the Adatum web app. 
 


### PR DESCRIPTION
Under DNS Name is the url but it is not a link you can copy and paste it but you cannot click it as the guide says so I fixed it.

![image](https://user-images.githubusercontent.com/28607803/45348373-5defdf00-b5a6-11e8-91d7-62e2af7e113b.png)
