### PR TITLE
Add note for missing output

### DIFF
--- a/Allfiles/Labfiles/Lab06/Starter/New-20533E06FileShare.ps1
+++ b/Allfiles/Labfiles/Lab06/Starter/New-20533E06FileShare.ps1
@@ -20,4 +20,4 @@ $sourceFolder = Join-Path -Path $rootPath -ChildPath 'Lab06\Starter\invoices'
 
 # Upload each file in the local folder to the directory in the share
 $files = Get-ChildItem -Path $sourceFolder -File
-foreach ($file in $files) { Set-AzureStorageFileContent -Share $share -Source "$sourcefolder\$file" -Path $directoryName}
+foreach ($file in $files) { Set-AzureStorageFileContent -Share $share -Source "$sourcefolder\$file" -Path $directoryName - Verbose}

--- a/Instructions/20533E_LAB_AK_06.md
+++ b/Instructions/20533E_LAB_AK_06.md
@@ -158,8 +158,9 @@ Set-AzureRmContext -SubscriptionId 'SubscriptionId'
 
 10. Save the script and then press the **F5** key.
 
-11. Observe the script as it runs, and then view the output. When you finish, close Windows PowerShell ISE.
+11. Observe the script as it runs. When you finish, close Windows PowerShell ISE.
 
+>> **Note:** Script produces no output on success
 
 
 #### Task 2: Access a file share from an Azure VM


### PR DESCRIPTION
The script  New-20533E06FileShare.ps1  produces no output on success so I added a note for people who might want to be looking for some confirmation.
![image](https://user-images.githubusercontent.com/28607803/45351162-61d32f80-b5ad-11e8-8808-c95996d8f52a.png)


Note: The script should be re-written to produce some output.

If you add -Verbose at the end of it you will at least see this:
![image](https://user-images.githubusercontent.com/28607803/45351436-18cfab00-b5ae-11e8-8a06-fada746dc60c.png)


I found the script in GitHub so I added the -Verbose for you but you need to ensure those are copied to VMs so I think my comment is still valid. Let me know if you want me to remove the comment but keep the -Verbose param.