### PR TITLE
fix syntax for bold next to username and password

### DIFF
--- a/Instructions/20533E_LAB_AK_07.md
+++ b/Instructions/20533E_LAB_AK_07.md
@@ -203,7 +203,7 @@ ssh student@$FQDN
 
 3. When prompted for the password, type **Pa55w.rd1234** and then press Enter. You should be presented with the **student@20533E0701-vm0** prompt.
 
-4. Within the SSH session to the Azure VM Docker host, to log in to the Azure Container registry you created in the first task, type the following, replacing the ***\<user name\>***, ***\<password\>***, and ***\<login-server\>*** entries with the values you identified in the previous task, and then press Enter: 
+4. Within the SSH session to the Azure VM Docker host, to log in to the Azure Container registry you created in the first task, type the following, replacing the ***\<user name\>*** , ***\<password\>*** , and ***\<login-server\>*** entries with the values you identified in the previous task, and then press Enter: 
 
 ```
 docker login --username <user name> --password <password> <login-server>


### PR DESCRIPTION
Syntax is wrong as it i needs a space to properly be converted, now it looks like this:
![image](https://user-images.githubusercontent.com/28607803/45359258-df099f00-b5c3-11e8-878c-b837498ce3cc.png)
