### PR TITLE
Missing word, changed nomenclature

### DIFF
--- a/Instructions/20533E_LAB_04.md
+++ b/Instructions/20533E_LAB_04.md
@@ -1,9 +1,9 @@
-﻿# Module 4: Managing virtual machines
+# Module 4: Managing virtual machines
 # Lab: Managing Azure virtual machines
   
 ### Scenario
   
- Now that you have validated basic deployment options of Azure VMs, you need to start testing more advanced configuration scenarios. Your plan is to step through a sample configuration a two-tier A. Datum ResDev application. As part of your tests, you will set up the front-end tier consisting of a pair of load balanced Azure VMs hosting IIS configured by using the VM DSC extension . You will also set up a multi-disk volume by using Storage Spaces in a Windows Azure VM in the back-end tier.
+ Now that you have validated basic deployment options of Azure VMs, you need to start testing more advanced configuration scenarios. Your plan is to step through a sample configuration of a two-tier A. Datum ResDev application. As part of your tests, you will set up the front-end tier consisting of a pair of load balanced Azure VMs hosting IIS configured by using the VM DSC extension. You will also set up a multi-disk volume by using Storage Spaces in a Windows Azure VM in the back-end tier.
 
 
 ### Objectives
@@ -30,7 +30,7 @@
   
 ### Scenario
   
- You need to test the ability of Azure VMs in the same availability set to operate in a load balanced configuration by leveraging Azure load balancer.  You also need to test the implementation of the desired state configuration in Azure by using VM Agent DSC extension to install the default IIS website on two Azure VMs that will host the web tier of the A. Datum ResDev application. Once the installation is complete, you must test the availability of this setup by verifying that load balanced access to the default website is not affected by shutting down one of the Azure VMs.
+ You need to test the ability of Azure VMs in the same availability set to operate in a load balanced configuration by leveraging Azure load balancer. You also need to test the implementation of the desired state configuration in Azure by using VM Agent DSC extension to install the default IIS website on two Azure VMs that will host the web tier of the A. Datum ResDev application. Once the installation is complete, you must test the availability of this setup by verifying that load balanced access to the default website is not affected by shutting down one of the Azure VMs.
 
 
 The main tasks for this exercise are as follows:
@@ -167,7 +167,7 @@ The main tasks for this exercise are as follows:
 
 > **Note:** This configuration will allow you to connect to both Azure VMs via RDP even though they do not have directly assigned public IP address.
 
-7. On the 20533E0401-ilb blade, review the **Essentials** section and identify the public IP address assigned to the load balancer. Note that at this point, you will not be able to connect to the two virtual machines in the backend pool, because they are not running a web server and the connectivity is additionally restricted by default network security group settings and the operating system-level firewall. You will change these settings later in this lab.
+7. On the 20533E0401-ilb blade, review the **Overview** section and identify the public IP address assigned to the load balancer. Note that at this point, you will not be able to connect to the two virtual machines in the backend pool, because they are not running a web server and the connectivity is additionally restricted by default network security group settings and the operating system-level firewall. You will change these settings later in this lab.
 
 
 #### Task 3: Install and configure IIS on Azure VMs by using DSC and Windows PowerShell
@@ -264,9 +264,9 @@ The main tasks for this exercise are as follows:
 
   - Name: **20533E0401-vm2-data01**
 
-  - Resource group: ensure that the **Use existing** option is selected and **20533E0401-LabRG** appears in the drop down list.
+  - Resource group: Select **20533E0401-LabRG** in the drop down list marked "Select Existing".
 
-  - Account type: **Standard\_LRS**
+  - Account type: **Standard\_SSD**
 
   - Source type: **None (empty disk)**
 
@@ -278,9 +278,9 @@ The main tasks for this exercise are as follows:
 
   - Name: **20533E0401-vm2-data02**
 
-  - Resource group: ensure that the **Use existing** option is selected and **20533E0401-LabRG** appears in the drop down list.
+  - Resource group: Select **20533E0401-LabRG** in the drop down list marked "Select Existing".
 
-  - Account type: **Standard\_LRS**
+  - Account type: **Standard\_SSD**
 
   - Source type: **None (empty disk)**
 
@@ -299,7 +299,7 @@ The main tasks for this exercise are as follows:
 
 4. From the Server Manager window, create a new volume of maximum size, mount it as the F: drive and format it with NTFS and a default allocation unit.
 
-5. From the desktop of 20533E0401-vm2, open File Explorer and verify that there is a new drive F.
+5. From the desktop of 20533E0401-vm2, open File Explorer and verify that there is a new drive F:.
 
 6. Close the Remote Desktop session to 20533E0401-vm2.
 


### PR DESCRIPTION
Added an _of_, minor reformatting (md-invisible, but nicer on the eye when editing)
Changed Essentials to Overview, which contains the public ip for load balancers.
Removed "use existing Resource Group" -- no longer an option.
Replaced Standard_LRS with Standard_SSD - LRS not an option with managed storage