### PR TITLE
Make Kube-deployment name DNS01123 compliant + minor fix for formatting

### DIFF
--- a/Instructions/20533E_LAB_07.md
+++ b/Instructions/20533E_LAB_07.md
@@ -333,7 +333,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Deploy a containerized application to the AKS cluster 
   
-1. In the Azure portal, in the Microsoft Edge window, in the Cloud shell pane, create a deployment named **nginx-20533E0703** using the nginx image from the Docker Hub by running the **kubectl run** command with the following parameters:
+1. In the Azure portal, in the Microsoft Edge window, in the Cloud shell pane, create a deployment named **nginx-20533e0703** using the nginx image from the Docker Hub by running the **kubectl run** command with the following parameters:
 
   - --image: **nginx**
 

--- a/Instructions/20533E_LAB_07.md
+++ b/Instructions/20533E_LAB_07.md
@@ -345,7 +345,7 @@ The main tasks for this exercise are as follows:
 
 3. Identify the state of the deployment by running **kubectl get deployment** command from the bash prompt in the Cloud Shell pane.
 
-4. Make the deployment **nginx-20533E0703** available from Internet by running **kubectl expose** command from the bash prompt in the Cloud Shell pane with the following parameters:
+4. Make the deployment **nginx-20533e0703** available from Internet by running **kubectl expose** command from the bash prompt in the Cloud Shell pane with the following parameters:
 
   - --port: **80** 
 
@@ -353,20 +353,20 @@ The main tasks for this exercise are as follows:
 
 5. Identify whether the public IP address has been provisioned by running **kubectl get services** command from the bash prompt in the Cloud Shell pane.
 
-6. Repeat step 5 until the value in the **EXTERNAL-IP** column for nginx-20533E0703 changes from **<<pending>pending>** to a public IP address. At that point, note the public IP address in the **EXTERNAL-IP** column for nginx-20533E0703. 
+6. Repeat step 5 until the value in the **EXTERNAL-IP** column for **nginx-20533e0703** changes from **\<pending\>** to a public IP address. At that point, note the public IP address in the **EXTERNAL-IP** column for **nginx-20533e0703**. 
 
 7. Start Microsoft Edge and browse to the IP address you obtained in the previous step. Verify that Microsoft Edge displays the **Welcome to nginx!** 
 
 
 #### Task 2: Manage deployment of a containerized application on the AKS cluster 
   
-1. Scale the deployment **nginx-20533E0703** by running **kubectl scale** command from the bash prompt in the Cloud Shell pane with the --replicas parameter set to **2**.
+1. Scale the deployment **nginx-20533e0703** by running **kubectl scale** command from the bash prompt in the Cloud Shell pane with the --replicas parameter set to **2**.
 
 2. Verify the outcome of scaling the deployment by running **kubectl get pods** command from the bash prompt in the Cloud Shell pane.
 
 3. In the output of the command you ran in the previous step, verify that the number of pods increased to 2.
 
-4. Delete the **nginx-20533E0703** deployment by running **kubectl delete** command from the bash prompt in the Cloud Shell pane.
+4. Delete the **nginx-20533e0703** deployment by running **kubectl delete** command from the bash prompt in the Cloud Shell pane.
 
 5. Verify that the command you ran in the previous step completed successfully by running **kubectl get deployment** command from the bash prompt in the Cloud Shell pane.
 


### PR DESCRIPTION
This allows copy-pasting the deployment name into the shell